### PR TITLE
fix(zsh): stabilize core shell init and tool setup

### DIFF
--- a/zsh/brew.sh
+++ b/zsh/brew.sh
@@ -5,8 +5,11 @@ elif isUbuntu; then
   brew_path="/home/linuxbrew/.linuxbrew/bin/brew"
 fi
 
-if $brew_path >/dev/null 2>&1; then
+if [ -x "$brew_path" ]; then
+  eval "$("$brew_path" shellenv)"
+elif [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  if [ -x "$brew_path" ]; then
+    eval "$("$brew_path" shellenv)"
+  fi
 fi
-
-eval "$($brew_path shellenv)"

--- a/zsh/cargo.sh
+++ b/zsh/cargo.sh
@@ -1,41 +1,50 @@
 ## Rust
-if [ ! -d ~/.cargo ]; then
+if [ ! -d ~/.cargo ] && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 fi
 
-source ~/.cargo/bin
-source ~/.cargo/env
-export PATH="$HOME/cargo/.bin:$PATH"
+if [ -f ~/.cargo/env ]; then
+  source ~/.cargo/env
+fi
+export PATH="$HOME/.cargo/bin:$PATH"
 
-export RUST_SRC_PATH=$(rustc --print sysroot)/lib/rustlib/src/rust/src/
+if exists rustc; then
+  export RUST_SRC_PATH="$(rustc --print sysroot)/lib/rustlib/src/rust/src/"
+fi
 
-if ! type eza > /dev/null 2>&1; then
+if ! exists eza && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
      cargo install eza
 fi
-alias ls=eza
+if exists eza; then
+  alias ls=eza
+fi
 
-if ! type bat > /dev/null 2>&1; then
+if ! exists bat && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
      cargo install bat
 fi
-alias cat=bat
+if exists bat; then
+  alias cat=bat
+fi
 
-if ! type delta > /dev/null 2>&1; then
+if ! exists delta && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
      cargo install git-delta
 fi
-alias git-delta=delta
+if exists delta; then
+  alias git-delta=delta
+fi
 
-if ! type rg > /dev/null 2>&1; then
+if ! exists rg && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
      cargo install ripgrep
 fi
 
-if ! type tokei > /dev/null 2>&1; then
+if ! exists tokei && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
      cargo install tokei
 fi
 
-if ! type btm > /dev/null 2>&1; then
+if ! exists btm && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
      cargo install bottom
 fi
 
-if ! type dust > /dev/null 2>&1; then
+if ! exists dust && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
      cargo install du-dust
 fi

--- a/zsh/gomi.sh
+++ b/zsh/gomi.sh
@@ -1,10 +1,11 @@
-alias rm="gomi"
-
-if isMac && ! exists gomi; then
+if isMac && ! exists gomi && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
   curl -LO https://github.com/babarot/gomi/releases/download/v1.1.6/gomi_darwin_arm64.tar.gz
   tar -xzvf gomi_darwin_arm64.tar.gz gomi
-  chmdo +x gomi
+  chmod +x gomi
   mv gomi ~/.bin/gomi
-  rm gomi_darwin_arm64.tar.gz
+  /bin/rm -f gomi_darwin_arm64.tar.gz
 fi
 
+if exists gomi; then
+  alias rm="gomi"
+fi

--- a/zsh/lib.sh
+++ b/zsh/lib.sh
@@ -79,11 +79,11 @@ UNAME=$(uname -s)
 loadsh() {
   if [ "$DEBUG" = true ]; then
     start=`python -c "import time; print(time.time_ns())"`
-    source $1
+    source "$1"
     end=`python -c "import time; print(time.time_ns())"`
     echo "${Bold}[${BIGreen}INFO${NC}${Bold}] Load $1 in $(($(($end - $start))/1000000)) ms${NC}"
   else
-    source $1
+    source "$1"
   fi
 }
 
@@ -96,7 +96,7 @@ isUbuntu() {
 }
 
 exists() {
-  which $1 1>/dev/null
+  command -v "$1" 1>/dev/null
 }
 
 install() {
@@ -106,11 +106,11 @@ install() {
 
 installMac() {
   if [ "$UNAME" = 'Darwin' ]; then
-    if ! which $1 1>/dev/null; then
+    if ! command -v "$1" 1>/dev/null; then
       if [ "$#" = 1 ]; then
-        brew install $1;
+        brew install "$1";
       elif [ "$#" = 2 ]; then
-        brew install $2;
+        brew install "$2";
       fi
     fi
   fi
@@ -119,18 +119,17 @@ installMac() {
 installUbuntu() {
   if [ "$#" = 1 ]; then
     if isUbuntu; then
-      if ! dpkg -s $1 1>/dev/null; then sudo apt -y install $1; fi
+      if ! dpkg -s "$1" 1>/dev/null; then sudo apt -y install "$1"; fi
     fi
   elif [ "$#" = 2 ]; then
     if isUbuntu; then
-      if ! dpkg -s $2 1>/dev/null; then sudo apt -y install $1; fi
+      if ! dpkg -s "$2" 1>/dev/null; then sudo apt -y install "$2"; fi
     fi
   fi
 }
 
 link() {
-  if [ ! -e $2 ]; then
-    ln -s $1 $2
+  if [ ! -e "$2" ]; then
+    ln -s "$1" "$2"
   fi
 }
-

--- a/zsh/nvim.sh
+++ b/zsh/nvim.sh
@@ -1,13 +1,13 @@
 ## nvim
 
 # vim-plug
-if [ ! -e "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim ]; then
+if [ ! -e "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim ] && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
     sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
        https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 fi
 
-local osversion=$(uname -s)
-if ! which nvim 1>/dev/null; then
+osversion=$(uname -s)
+if ! exists nvim && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
   if [ "${osversion:0:5}" = 'Linux' ]; then
     sudo apt-add-repository -y ppa:neovim-ppa/stable
     sudo apt update
@@ -15,9 +15,15 @@ if ! which nvim 1>/dev/null; then
   elif [ "${osversion:0:6}" = 'Darwin' ]; then
     brew install neovim
   fi
-  pip install neovim
+  if exists pip; then
+    pip install neovim
+  fi
 
-  nvim +PlugInstall
-else
+  if exists nvim; then
+    nvim +PlugInstall
+  fi
+fi
+
+if exists nvim; then
   alias vim='nvim'
 fi


### PR DESCRIPTION
## Problem
Shell init scripts were performing installs and setup during normal startup and included several robustness issues (unsafe command checks, typo, path handling), causing failures and side effects.

## Changes
- Hardened shared helpers in `zsh/lib.sh` (`command -v`, quoting, ubuntu install arg fix).
- Fixed Homebrew init flow in `zsh/brew.sh` and gated installer behind `DOTFILES_BOOTSTRAP=true`.
- Fixed Rust init in `zsh/cargo.sh` (`~/.cargo/env` guard, correct `~/.cargo/bin`, conditional aliases/tools).
- Fixed `zsh/nvim.sh` startup behavior and gated bootstrap installs/actions.
- Fixed `zsh/gomi.sh` typo (`chmod`), safe cleanup, and alias timing.

## Verification
- `zsh -n zsh/*.sh zsh/zshrc zsh/p10k.zsh zsh/zinit.sh` passes.
- Confirmed install/download actions are now opt-in via `DOTFILES_BOOTSTRAP=true`.
