### PR TITLE
refactor(zsh): gate install side effects behind DOTFILES_BOOTSTRAP

### DIFF
--- a/zsh/deno.sh
+++ b/zsh/deno.sh
@@ -1,4 +1,6 @@
-if [ ! -x "`which deno`" ]; then
+if ! exists deno && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
   # curl -fsSL https://deno.land/x/install/install.sh | sh
-  cargo install deno --locked
+  if exists cargo; then
+    cargo install deno --locked
+  fi
 fi

--- a/zsh/gh.sh
+++ b/zsh/gh.sh
@@ -1,13 +1,15 @@
 # gh command
-if isUbuntu && ! exists gh; then
+if isUbuntu && ! exists gh && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
   type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
   curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
   && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
   && sudo apt update \
   && sudo apt install gh -y
-elif isMac && ! exists gh; then
+elif isMac && ! exists gh && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
   brew install gh
 fi
 
-source <(gh completion -s zsh)
+if exists gh; then
+  source <(gh completion -s zsh)
+fi

--- a/zsh/go.sh
+++ b/zsh/go.sh
@@ -1,3 +1,8 @@
 # Import Go environment variables
-. ~/.asdf/plugins/golang/set-env.zsh
-go install golang.org/x/tools/gopls@latest
+if [ -f ~/.asdf/plugins/golang/set-env.zsh ]; then
+  . ~/.asdf/plugins/golang/set-env.zsh
+fi
+
+if exists go && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
+  go install golang.org/x/tools/gopls@latest
+fi

--- a/zsh/krew.sh
+++ b/zsh/krew.sh
@@ -1,7 +1,7 @@
 export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 
 # Install krew
-if ! kubectl krew 2>&1 >/dev/null; then
+if exists kubectl && ! kubectl krew >/dev/null 2>&1 && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
   (
     set -x; cd "$(mktemp -d)" &&
     OS="$(uname | tr '[:upper:]' '[:lower:]')" &&

--- a/zsh/kubectl.sh
+++ b/zsh/kubectl.sh
@@ -1,12 +1,14 @@
 if ! exists kubectl; then
-  if isMac; then
+  if isMac && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
     brew install kubectl
   fi
 fi
 
-alias k=kubectl
+if exists kubectl; then
+  alias k=kubectl
 
-# If _kubectl completions exists in fpath, skip set completions
-if [ ! -f "${fpath[1]}/_kubectl" ] &>/dev/null; then
-  kubectl completion zsh > "${fpath[1]}/_kubectl"
+  # If _kubectl completions exists in fpath, skip set completions
+  if [ ! -f "${fpath[1]}/_kubectl" ] &>/dev/null; then
+    kubectl completion zsh > "${fpath[1]}/_kubectl"
+  fi
 fi

--- a/zsh/pkg.sh
+++ b/zsh/pkg.sh
@@ -1,29 +1,31 @@
-installUbuntu git
-installUbuntu zsh
-installUbuntu tmux
-installUbuntu curl
-installUbuntu wget
-installUbuntu build-essential
-installUbuntu libbz2-dev
-installUbuntu libdb-dev
-installUbuntu libreadline-dev
-installUbuntu libffi-dev
-installUbuntu libgdbm-dev
-installUbuntu liblzma-dev
-installUbuntu libncursesw5-dev
-installUbuntu libsqlite3-dev
-installUbuntu libssl-dev
-installUbuntu zlib1g-dev
-installUbuntu uuid-dev
-installUbuntu tk-dev
-installUbuntu llvm
-installUbuntu clang
-installUbuntu cmake
-installUbuntu protobuf-compiler
-installUbuntu ca-certificates
+if [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
+  installUbuntu git
+  installUbuntu zsh
+  installUbuntu tmux
+  installUbuntu curl
+  installUbuntu wget
+  installUbuntu build-essential
+  installUbuntu libbz2-dev
+  installUbuntu libdb-dev
+  installUbuntu libreadline-dev
+  installUbuntu libffi-dev
+  installUbuntu libgdbm-dev
+  installUbuntu liblzma-dev
+  installUbuntu libncursesw5-dev
+  installUbuntu libsqlite3-dev
+  installUbuntu libssl-dev
+  installUbuntu zlib1g-dev
+  installUbuntu uuid-dev
+  installUbuntu tk-dev
+  installUbuntu llvm
+  installUbuntu clang
+  installUbuntu cmake
+  installUbuntu protobuf-compiler
+  installUbuntu ca-certificates
 
-installMac reattach-to-user-namespace
-installMac tmux
-installMac cmake
-installMac gpg
-installMac pipx
+  installMac reattach-to-user-namespace
+  installMac tmux
+  installMac cmake
+  installMac gpg
+  installMac pipx
+fi

--- a/zsh/poetry.sh
+++ b/zsh/poetry.sh
@@ -1,3 +1,3 @@
-if [ ! -f ~/.local/bin/poetry ]; then
-  pipx instlal poetry
+if [ ! -f ~/.local/bin/poetry ] && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
+  pipx install poetry
 fi

--- a/zsh/protobuf.sh
+++ b/zsh/protobuf.sh
@@ -1,5 +1,5 @@
 if isMac ;then
-  if ! exists protoc; then
+  if ! exists protoc && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
     brew install protobuf
   fi
 fi

--- a/zsh/tmux.sh
+++ b/zsh/tmux.sh
@@ -1,5 +1,5 @@
 link ~/.dotfiles/tmux.conf ~/.tmux.conf
 ## tmux plugin
-if [ ! -d ~/.tmux/plugins/tpm ]; then
+if [ ! -d ~/.tmux/plugins/tpm ] && [ "${DOTFILES_BOOTSTRAP:-false}" = "true" ]; then
     git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
 fi


### PR DESCRIPTION
## Problem
Normal shell startup triggered package installs and networked setup in multiple scripts, creating side effects and brittle boot behavior.

## Changes
- Added `DOTFILES_BOOTSTRAP=true` gate to install/setup flows in:
  - `zsh/pkg.sh`
  - `zsh/gh.sh`
  - `zsh/kubectl.sh`
  - `zsh/krew.sh`
  - `zsh/go.sh`
  - `zsh/poetry.sh`
  - `zsh/deno.sh`
  - `zsh/protobuf.sh`
  - `zsh/tmux.sh`
- Added command/file existence guards before running tool-specific commands.
- Fixed `pipx instlal` typo to `pipx install`.

## Verification
- Confirmed these scripts no longer perform install side effects unless `DOTFILES_BOOTSTRAP=true`.
- Verified syntax via `zsh -n` on zsh scripts.
