### PR TITLE
fix(config): repair symlink path and keybinding/config inconsistencies

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -24,8 +24,8 @@ end
 
 # symbolic link
 function link
-  if test ! -e $argv[1]
-    # ln -s $argv[1] $argv[2]
+  if test ! -e $argv[2]
+    ln -s $argv[1] $argv[2]
   end
 end
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -17,7 +17,7 @@ bind-key k select-pane -U
 bind-key l select-pane -R
 bind-key : command-prompt
 bind-key r refresh-client
-bind-key r source-file ~/.tmux.conf
+bind-key R source-file ~/.tmux.conf
 
 # keybinding for toggling panes synchronization:
 bind-key = set-window-option synchronize-panes

--- a/zsh/symbolic-link.sh
+++ b/zsh/symbolic-link.sh
@@ -1,6 +1,6 @@
 # symbolic link
 # .zshrc
-link ~/.dotfiles/zsh/.zshrc ~/.zshrc
+link ~/.dotfiles/zsh/zshrc ~/.zshrc
 
 # .gitconfig
 link ~/.dotfiles/gitconfig ~/.gitconfig


### PR DESCRIPTION
## Problem
A few config inconsistencies caused setup and UX issues:
- wrong zshrc symlink source path,
- duplicate tmux binding on `r`,
- fish `link` function checking wrong argument and not creating links.

## Changes
- `zsh/symbolic-link.sh`: fixed source path to `~/.dotfiles/zsh/zshrc`.
- `tmux.conf`: changed reload binding to `R` to avoid conflict with refresh on `r`.
- `fish/config.fish`: fixed destination check (`$argv[2]`) and enabled `ln -s`.

## Verification
- `zsh -n zsh/symbolic-link.sh` passes.
- `tmux.conf` change is syntactically valid and resolves key collision.
- `fish -n` could not run in this environment (`fish` not installed).
